### PR TITLE
copy msbuild for 64bit also

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,16 +1,17 @@
 
-:: Need to move a more current msbuild into PATH.  32-bit one in particular on AppVeyor barfs on the solution
-::     This one comes from the Win7 SDK (.net 4.0), and is known to work.
 if %ARCH% == 64 (
     set PLATF=x64
-	set OUTDIR=Win64
+    set OUTDIR=Win64
 ) else (
-    if %VS_MAJOR% == 9 (
-        COPY C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe .\
-        set "PATH=%CD%;%PATH%"
-    )
     set PLATF=Win32
-	set OUTDIR=Win32
+    set OUTDIR=Win32
+)
+
+:: Need to move a more current msbuild into PATH.  The one onn AppVeyor barfs on the solution
+::     This one comes from the Win7 SDK (.net 4.0), and is known to work.
+if %VS_MAJOR% == 9 (
+    COPY C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe .\
+    set "PATH=%CD%;%PATH%"
 )
 
 set XERCESVC=VC%VS_MAJOR%


### PR DESCRIPTION
Something seems to have changed on appveyor. We used to only have to do this for 32bit on VS2008...